### PR TITLE
DE-5143: bump rest high level client version to fix connector compatibility with OS 2.x

### DIFF
--- a/flink-connector-opensearch/pom.xml
+++ b/flink-connector-opensearch/pom.xml
@@ -36,7 +36,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<opensearch.version>1.3.0</opensearch.version>
+		<opensearch.version>2.3.0</opensearch.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/streaming/connectors/opensearch/OpensearchSinkTest.java
@@ -130,7 +130,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
         testHarness.open();
@@ -169,7 +168,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
         testHarness.processElement(new StreamRecord<>("msg"));
@@ -207,7 +205,7 @@ public class OpensearchSinkTest {
                                 1,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "1", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "1", 0, 0, 1, true))));
 
         responses.add(
                 createResponse(
@@ -216,7 +214,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "2",
                                         new Exception("artificial failure for record")))));
 
@@ -335,7 +332,7 @@ public class OpensearchSinkTest {
                                 1,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "1", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "1", 0, 0, 1, true))));
 
         // Let the whole bulk request fail
         responses.add(response -> response.setStatusCode(500));
@@ -398,7 +395,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
 
@@ -408,7 +404,7 @@ public class OpensearchSinkTest {
                                 2,
                                 OpType.INDEX,
                                 new IndexResponse(
-                                        new ShardId("test", "-", 0), "_doc", "2", 0, 0, 1, true))));
+                                        new ShardId("test", "-", 0), "2", 0, 0, 1, true))));
 
         testHarness.processElement(new StreamRecord<>("msg"));
 
@@ -474,7 +470,6 @@ public class OpensearchSinkTest {
                                 OpType.INDEX,
                                 new Failure(
                                         "test",
-                                        "_doc",
                                         "1",
                                         new Exception("artificial failure for record")))));
 
@@ -514,7 +509,7 @@ public class OpensearchSinkTest {
             Map<java.lang.String, Object> json = new HashMap<>();
             json.put("data", element);
 
-            indexer.add(Requests.indexRequest().index("index").type("type").id("id").source(json));
+            indexer.add(Requests.indexRequest().index("index").id("id").source(json));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,23 @@ under the License.
 		<flink.parent.artifactId>flink-connector-opensearch-parent</flink.parent.artifactId>
 	</properties>
 
+	<distributionManagement>
+		<repository>
+			<id>decodable-mvn-releases-local</id>
+			<name>Decodable mvn Releases Local</name>
+			<url>
+				https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-releases-local
+			</url>
+		</repository>
+		<snapshotRepository>
+			<id>decodable-mvn-snapshots-local</id>
+			<name>Decodable mvn Snapshots Local</name>
+			<url>
+				https://decodable-671293015970.d.codeartifact.us-west-2.amazonaws.com/maven/decodable-mvn-snapshots-local
+			</url>
+		</snapshotRepository>
+	</distributionManagement>
+
 	<dependencies>
 		<!-- Root dependencies for all projects -->
 


### PR DESCRIPTION
## Description

Currently, the upstream opensearch connector fails at runtime while parsing OS 2.x server responses. This is happening because the Osearch high level rest client is out of sync with OS 2.x (specifically, the client expects a `type` field that is no longer included in the response body). This has been removed from the rest client in version 2.3.

There's an open PR for the issue upstream with the exact same change: https://github.com/apache/flink-connector-opensearch/pull/4. Until this is sorted, this will have to do.

## Validation
- [x] send records to OS on AWS
- [x] send data to self hosted OS

## Security Considerations

Are there any security or data concerns to consider? If so, please describe them below.
This may include, but is not limited to:

 - Potential SQL injection
 - Handling customer credentials
 - Sensitive information in log messages
 - Dependencies with known vulnerabilities
 - Other issues listed in the OWASP [Top 10](https://owasp.org/Top10/)
 - [ ] Yes
 - [x] No

## Type of change
- [ ] Task - An internal-only task that has no visible customer effect.
- [ ] New feature - New functionality that is user-visible.
- [ ] Improvement - Existing functionality works better than it did before.
- [x] Bug fix - Something didn’t work as expected, but now it does.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (please describe)

## Documentation

- [ ] This pull request introduce a new feature

If yes, how is the feature documented?
- [x] Not applicable
- [ ] Docs - Please provide [links to docs]()
- [ ] Javadocs
- [ ] Not documented

## Checklists
- [x] Pull request has a descriptive title linked with JIRA ticket in the format `DE-XXXX: Summary` 
  where DE is the JIRA project short code, XXXX is the number, and Summary is the JIRA summary.
- [x] Pull request has reviewers assigned.
