### PR TITLE
DE-7165: Only suppress exceptions with unique root causes

### DIFF
--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterUnitTest.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterUnitTest.java
@@ -1,0 +1,102 @@
+package org.apache.flink.connector.opensearch.sink;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+
+import java.io.IOException;
+
+public class OpensearchWriterUnitTest {
+
+    private static final String MAPPER_PARSING_EXCEPTION_TEMPLATE =
+            "OpenSearch exception [type=mapper_parsing_exception, reason=object mapping for [{}] tried to parse field [{}] as object, but got EOF, has a concrete value been provided to it?]";
+
+    private static final String ILLEGAL_ARGUMENT_EXCEPTION =
+            "OpenSearch exception [type=illegal_argument_exception, reason=failed to parse date field [{}] with format [strict_date_optional_time||epoch_millis]]";
+    private static final String ROOT_CAUSE_EXCEPTION =
+            "OpenSearch exception [type=date_time_parse_exception, reason=parse_exception: Failed to parse field [{}]]";
+
+    @Test
+    public void testDedup() throws IOException {
+        // Simulate three failed responses with the same root cause and one with a distinct root
+        // cause. The
+        // resulting exception should only include 1 suppressed exception.
+        BulkItemResponse[] responses =
+                new BulkItemResponse[] {
+                    new BulkItemResponse(
+                            1,
+                            DocWriteRequest.OpType.UPDATE,
+                            new BulkItemResponse.Failure(
+                                    "index",
+                                    "id",
+                                    new OpenSearchException(
+                                            MAPPER_PARSING_EXCEPTION_TEMPLATE,
+                                            new OpenSearchException(
+                                                    ILLEGAL_ARGUMENT_EXCEPTION,
+                                                    new OpenSearchException(
+                                                            ROOT_CAUSE_EXCEPTION, "date_field1"),
+                                                    "date_field1"),
+                                            "_doc",
+                                            "first_message"))),
+                    new BulkItemResponse(
+                            2,
+                            DocWriteRequest.OpType.UPDATE,
+                            new BulkItemResponse.Failure(
+                                    "index",
+                                    "id",
+                                    new OpenSearchException(
+                                            MAPPER_PARSING_EXCEPTION_TEMPLATE,
+                                            new OpenSearchException(
+                                                    ILLEGAL_ARGUMENT_EXCEPTION,
+                                                    new OpenSearchException(
+                                                            ROOT_CAUSE_EXCEPTION, "date_field1"),
+                                                    "date_field1"),
+                                            "_doc",
+                                            "first_message"))),
+                    new BulkItemResponse(
+                            3,
+                            DocWriteRequest.OpType.UPDATE,
+                            new BulkItemResponse.Failure(
+                                    "index",
+                                    "id",
+                                    new OpenSearchException(
+                                            MAPPER_PARSING_EXCEPTION_TEMPLATE,
+                                            new OpenSearchException(
+                                                    ILLEGAL_ARGUMENT_EXCEPTION,
+                                                    new OpenSearchException(
+                                                            ROOT_CAUSE_EXCEPTION, "date_field2"),
+                                                    "date_field2"),
+                                            "_doc",
+                                            "first_message"))),
+                    new BulkItemResponse(
+                            4,
+                            DocWriteRequest.OpType.UPDATE,
+                            new BulkItemResponse.Failure(
+                                    "index",
+                                    "id",
+                                    new OpenSearchException(
+                                            MAPPER_PARSING_EXCEPTION_TEMPLATE,
+                                            new OpenSearchException(
+                                                    ILLEGAL_ARGUMENT_EXCEPTION,
+                                                    new OpenSearchException(
+                                                            ROOT_CAUSE_EXCEPTION, "date_field1"),
+                                                    "date_field1"),
+                                            "_doc",
+                                            "first_message")))
+                };
+
+        BulkResponse bulkResponse = new BulkResponse(responses, 1);
+
+        try {
+            OpensearchWriter.dedupBulkResponseExceptionsAndHandleFailures(
+                    bulkResponse, OpensearchWriter.DEFAULT_FAILURE_HANDLER);
+        } catch (FlinkRuntimeException e) {
+            Assertions.assertEquals(1, e.getCause().getSuppressed().length);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Description

context: https://decodable.slack.com/archives/C02AG8W5BT9/p1720569429719649

The Opensearch `BulkResponse` contains a single `Throwable` per failing document in the bulk request. The connector currently loops through the failures, combines them into a single exception via suppression, and throws it. In cases where the bulk size is very large (>>1000 responses), the size of the resulting stack trace is so large that serializing it causes the TM to OOM.

To mitigate this issue, only suppress exceptions from a bulk response with unique root causes - this way, we can avoid massively nested stack traces where the root cause of every failure is the exact same (as we were seeing with Clint).

NOTE that this fix does **not** mitigate the unlikely case in which every failing document in a very large `BulkResponse` has a different root cause. This is acceptable for now judging by how infrequently this would occur, but it is worth revisiting in the future if it becomes a problem.

## 🔒 Security Considerations

Are there any security or data concerns to consider? 
 - [ ] Yes -> Please describe them below.
 - [x] No

These may include, but is not limited to:
 - Potential SQL injection
 - Handling customer credentials
 - Sensitive information in log messages
 - Dependencies with known vulnerabilities
 - Other issues listed in the OWASP [Top 10](https://owasp.org/Top10/)

## 📎 Type of change

- [ ] Task - An internal-only task that has no visible customer effect.
- [ ] New feature - New functionality that is user-visible.
- [ ] Improvement - Existing functionality works better than it did before.
- [x] Bug fix - Something didn’t work as expected, but now it does.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (please describe)

## 📄 Documentation

Any new features, or user-facing functionality that has changed must be documented. 
_The process is documented [here](https://docs.google.com/presentation/d/1Pbcwu__eURAHxPeeysp7ngDZ-M07L_MzJgTBEY8C8LU/edit#slide=id.g27149df37e6_0_0)_

Are there any documentation changes or additions required as a result of this PR?
 - [ ] Yes -> Please check one of the following.
	- [ ] This PR includes the required documentation changes and I've tagged `@rmoff` for review.
	- [ ] This PR does not include the required documentation changes, but to track this I've logged the following JIRA: DE-xxxx
	- [ ] Javadocs
 - [ ] No


## 📋 Checklists
- [x] Pull request has a descriptive title linked with JIRA ticket in the format `DE-XXXX: Summary` 
        where DE is the JIRA project short code, XXXX is the number, and Summary is the JIRA summary.
- [x] Pull request has reviewers assigned.
