### PR TITLE
DE-7188: add javadoc to OpensearchWriterUnitTest

### DIFF
--- a/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterUnitTest.java
+++ b/flink-connector-opensearch/src/test/java/org/apache/flink/connector/opensearch/sink/OpensearchWriterUnitTest.java
@@ -11,6 +11,7 @@ import org.opensearch.action.bulk.BulkResponse;
 
 import java.io.IOException;
 
+/** Unit tests for {@link OpensearchWriter}. */
 public class OpensearchWriterUnitTest {
 
     private static final String MAPPER_PARSING_EXCEPTION_TEMPLATE =


### PR DESCRIPTION
## 📝 Description

context: https://decodable.slack.com/archives/C02AG8W5BT9/p1720569429719649

Missed this in https://github.com/decodableco/flink-connector-opensearch/pull/7 - add a javadoc to the unit test so that deploy to codeartifact succeeds.

## 🔒 Security Considerations

Are there any security or data concerns to consider? 
 - [ ] Yes -> Please describe them below.
 - [x] No

These may include, but is not limited to:
 - Potential SQL injection
 - Handling customer credentials
 - Sensitive information in log messages
 - Dependencies with known vulnerabilities
 - Other issues listed in the OWASP [Top 10](https://owasp.org/Top10/)

## 📎 Type of change

- [ ] Task - An internal-only task that has no visible customer effect.
- [ ] New feature - New functionality that is user-visible.
- [ ] Improvement - Existing functionality works better than it did before.
- [x] Bug fix - Something didn’t work as expected, but now it does.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (please describe)

## 📄 Documentation

Any new features, or user-facing functionality that has changed must be documented. 
_The process is documented [here](https://docs.google.com/presentation/d/1Pbcwu__eURAHxPeeysp7ngDZ-M07L_MzJgTBEY8C8LU/edit#slide=id.g27149df37e6_0_0)_

Are there any documentation changes or additions required as a result of this PR?
 - [ ] Yes -> Please check one of the following.
	- [ ] This PR includes the required documentation changes and I've tagged `@rmoff` for review.
	- [ ] This PR does not include the required documentation changes, but to track this I've logged the following JIRA: DE-xxxx
	- [ ] Javadocs
 - [x] No


## 📋 Checklists
- [x] Pull request has a descriptive title linked with JIRA ticket in the format `DE-XXXX: Summary` 
        where DE is the JIRA project short code, XXXX is the number, and Summary is the JIRA summary.
- [x] Pull request has reviewers assigned.
